### PR TITLE
Lone mountain world generator

### DIFF
--- a/src/main/java/org/terasology/additionalworlds/lonemountain/GaussianSurfaceProvider.java
+++ b/src/main/java/org/terasology/additionalworlds/lonemountain/GaussianSurfaceProvider.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.additionalworlds.lonemountain;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.math.geom.BaseVector2i;
+import org.terasology.math.geom.Rect2i;
+import org.terasology.math.geom.Vector2f;
+import org.terasology.rendering.nui.properties.Range;
+import org.terasology.world.generation.Border3D;
+import org.terasology.world.generation.ConfigurableFacetProvider;
+import org.terasology.world.generation.GeneratingRegion;
+import org.terasology.world.generation.Produces;
+import org.terasology.world.generation.facets.SurfaceHeightFacet;
+
+@Produces(SurfaceHeightFacet.class)
+public class GaussianSurfaceProvider implements ConfigurableFacetProvider {
+    private GaussianSurfaceSampler surfaceSampler;
+
+    private GaussianSurfaceConfiguration configuration = new GaussianSurfaceConfiguration();
+
+    @Override
+    public void initialize() {
+        Vector2f radius = new Vector2f(configuration.mountainRadiusX, configuration.mountainRadiusY);
+        surfaceSampler = new GaussianSurfaceSampler(Vector2f.zero(), radius, configuration.mountainHeight);
+    }
+
+    @Override
+    public void process(GeneratingRegion region) {
+        Border3D border = region.getBorderForFacet(SurfaceHeightFacet.class);
+        SurfaceHeightFacet facet = new SurfaceHeightFacet(region.getRegion(), border);
+
+        Rect2i processRegion = facet.getWorldRegion();
+        for (BaseVector2i position : processRegion.contents()) {
+            facet.setWorld(position, surfaceSampler.sample(new Vector2f(position.x(), position.y())));
+        }
+
+        region.setRegionFacet(SurfaceHeightFacet.class, facet);
+    }
+
+    @Override
+    public String getConfigurationName() {
+        return "Lone Mountain";
+    }
+
+    @Override
+    public Component getConfiguration() {
+        return configuration;
+    }
+
+    @Override
+    public void setConfiguration(Component configuration) {
+        this.configuration = (GaussianSurfaceConfiguration) configuration;
+    }
+
+    private static class GaussianSurfaceConfiguration implements Component {
+        @Range(min = 20, max = 500, increment = 10, description = "Mountain Height")
+        public float mountainHeight = 400;
+
+        @Range(min = 10, max = 1000, increment = 10, description = "Mountain Radius X")
+        public float mountainRadiusX = 200;
+
+        @Range(min = 10, max = 1000, increment = 10, description = "Mountain Radius Y")
+        public float mountainRadiusY = 200;
+    }
+}

--- a/src/main/java/org/terasology/additionalworlds/lonemountain/GaussianSurfaceSampler.java
+++ b/src/main/java/org/terasology/additionalworlds/lonemountain/GaussianSurfaceSampler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.additionalworlds.lonemountain;
+
+import org.terasology.math.geom.Vector2f;
+
+public final class GaussianSurfaceSampler {
+    public final float height;
+    public final Vector2f radius;
+    public final Vector2f center;
+
+    public GaussianSurfaceSampler(Vector2f center, Vector2f radius, float height) {
+        this.height = height;
+        this.radius = radius;
+        this.center = center;
+    }
+
+    public float sample(Vector2f point) {
+        Vector2f normalizedOffset = point.sub(center);
+        normalizedOffset.divX(radius.x);
+        normalizedOffset.divY(radius.y);
+
+        return (float) (height / Math.exp(normalizedOffset.lengthSquared() / 2));
+    }
+}

--- a/src/main/java/org/terasology/additionalworlds/lonemountain/LoneMountainRasterizer.java
+++ b/src/main/java/org/terasology/additionalworlds/lonemountain/LoneMountainRasterizer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.additionalworlds.lonemountain;
+
+import org.terasology.math.ChunkMath;
+import org.terasology.math.geom.Vector3i;
+import org.terasology.registry.CoreRegistry;
+import org.terasology.world.block.Block;
+import org.terasology.world.block.BlockManager;
+import org.terasology.world.chunks.CoreChunk;
+import org.terasology.world.generation.Region;
+import org.terasology.world.generation.WorldRasterizer;
+import org.terasology.world.generation.facets.SurfaceHeightFacet;
+
+public class LoneMountainRasterizer implements WorldRasterizer {
+    private Block dirt;
+
+    @Override
+    public void initialize() {
+        dirt = CoreRegistry.get(BlockManager.class).getBlock("Core:Dirt");
+    }
+
+    @Override
+    public void generateChunk(CoreChunk chunk, Region chunkRegion) {
+        SurfaceHeightFacet surfaceHeightFacet = chunkRegion.getFacet(SurfaceHeightFacet.class);
+        for (Vector3i position : chunkRegion.getRegion()) {
+            float surfaceHeight = surfaceHeightFacet.getWorld(position.x, position.z);
+            if (position.y < surfaceHeight) {
+                chunk.setBlock(ChunkMath.calcBlockPos(position), dirt);
+            }
+        }
+    }
+}

--- a/src/main/java/org/terasology/additionalworlds/lonemountain/LoneMountainTreeProvider.java
+++ b/src/main/java/org/terasology/additionalworlds/lonemountain/LoneMountainTreeProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.additionalworlds.lonemountain;
+
+import org.terasology.core.world.generator.facets.TreeFacet;
+import org.terasology.core.world.generator.trees.Trees;
+import org.terasology.math.TeraMath;
+import org.terasology.math.geom.Vector2i;
+import org.terasology.math.geom.Vector3i;
+import org.terasology.world.generation.Border3D;
+import org.terasology.world.generation.Facet;
+import org.terasology.world.generation.FacetProvider;
+import org.terasology.world.generation.GeneratingRegion;
+import org.terasology.world.generation.Produces;
+import org.terasology.world.generation.Requires;
+import org.terasology.world.generation.facets.SurfaceHeightFacet;
+
+@Produces(TreeFacet.class)
+@Requires(@Facet(SurfaceHeightFacet.class))
+public class LoneMountainTreeProvider implements FacetProvider {
+    private static final Vector2i TREE_SURFACE_POSITION = new Vector2i(0, 0);
+
+    @Override
+    public void process(GeneratingRegion region) {
+
+        SurfaceHeightFacet surfaceFacet = region.getRegionFacet(SurfaceHeightFacet.class);
+
+        int maxRad = 13;
+        int maxHeight = 32;
+        Border3D borderForTreeFacet = region.getBorderForFacet(TreeFacet.class);
+        TreeFacet facet = new TreeFacet(region.getRegion(), borderForTreeFacet.extendBy(0, maxHeight, maxRad));
+
+        if (surfaceFacet.getWorldRegion().contains(TREE_SURFACE_POSITION)) {
+            Vector3i treePosition = new Vector3i(TREE_SURFACE_POSITION.x,
+                    TeraMath.floorToInt(surfaceFacet.getWorld(TREE_SURFACE_POSITION)),
+                    TREE_SURFACE_POSITION.y);
+
+            if (facet.getWorldRegion().encompasses(treePosition)) {
+                facet.setWorld(treePosition, Trees.pineTree());
+            }
+        }
+
+        region.setRegionFacet(TreeFacet.class, facet);
+    }
+}

--- a/src/main/java/org/terasology/additionalworlds/lonemountain/LoneMountainWorldGenerator.java
+++ b/src/main/java/org/terasology/additionalworlds/lonemountain/LoneMountainWorldGenerator.java
@@ -15,7 +15,9 @@
  */
 package org.terasology.additionalworlds.lonemountain;
 
+import org.terasology.core.world.generator.facetProviders.BiomeProvider;
 import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
+import org.terasology.core.world.generator.rasterizers.TreeRasterizer;
 import org.terasology.engine.SimpleUri;
 import org.terasology.registry.In;
 import org.terasology.world.generation.BaseFacetedWorldGenerator;
@@ -35,8 +37,10 @@ public class LoneMountainWorldGenerator extends BaseFacetedWorldGenerator {
     @Override
     protected WorldBuilder createWorld() {
         return new WorldBuilder(worldGeneratorPluginLibrary)
-                .addProvider(new GaussianSurfaceProvider())
                 .addProvider(new SeaLevelProvider(0))
-                .addRasterizer(new LoneMountainRasterizer());
+                .addProvider(new GaussianSurfaceProvider())
+                .addProvider(new LoneMountainTreeProvider())
+                .addRasterizer(new LoneMountainRasterizer())
+                .addRasterizer(new TreeRasterizer());
     }
 }

--- a/src/main/java/org/terasology/additionalworlds/lonemountain/LoneMountainWorldGenerator.java
+++ b/src/main/java/org/terasology/additionalworlds/lonemountain/LoneMountainWorldGenerator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.additionalworlds.lonemountain;
+
+import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
+import org.terasology.engine.SimpleUri;
+import org.terasology.registry.In;
+import org.terasology.world.generation.BaseFacetedWorldGenerator;
+import org.terasology.world.generation.WorldBuilder;
+import org.terasology.world.generator.RegisterWorldGenerator;
+import org.terasology.world.generator.plugin.WorldGeneratorPluginLibrary;
+
+@RegisterWorldGenerator(id = "loneMountain", displayName = "Lone Mountain")
+public class LoneMountainWorldGenerator extends BaseFacetedWorldGenerator {
+    @In
+    private WorldGeneratorPluginLibrary worldGeneratorPluginLibrary;
+
+    public LoneMountainWorldGenerator(SimpleUri uri) {
+        super(uri);
+    }
+
+    @Override
+    protected WorldBuilder createWorld() {
+        return new WorldBuilder(worldGeneratorPluginLibrary)
+                .addProvider(new GaussianSurfaceProvider())
+                .addProvider(new SeaLevelProvider(0))
+                .addRasterizer(new LoneMountainRasterizer());
+    }
+}


### PR DESCRIPTION
## Terrain
The terrain consists of a _single_ mountain whose surface is sampled by the 2D Gaussian function. The world is _entirely flat otherwise_. The mountain height and gaussian surface radii can be configured.

## Screenshots
### The mountain
Height: 40
Radius: (30, 30)

![screenshot_20180114_221553](https://user-images.githubusercontent.com/8018181/34918455-a28f875e-f978-11e7-9e80-78ce35f820b2.png)

### View from top of the mountain
![screenshot_20180114_222615](https://user-images.githubusercontent.com/8018181/34918540-f596aa62-f979-11e7-8d30-56503d241648.png)
